### PR TITLE
Feature/#9 credential migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
     implementation(Google.FIREBASE_FIRESTORE)
     implementation(Google.FIREBASE_CLOUD_FUNCTION)
     implementation(Google.FIREBASE_CLOUD_MESSAGING)
+    implementation(Google.CREDENTIAL_PLAY_SERVICE)
+    implementation(Google.CREDENTIAL)
+    implementation(Google.GOOGLE_ID)
     implementation(Permission.TED_NORMAL)
     implementation(Permission.TED_COROUTINE)
 }

--- a/app/src/main/java/com/ping/app/data/repository/login/LoginRepo.kt
+++ b/app/src/main/java/com/ping/app/data/repository/login/LoginRepo.kt
@@ -1,15 +1,16 @@
 package com.ping.app.data.repository.login
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 
 interface LoginRepo {
     fun getCurrentAuth(): FirebaseAuth?
-    fun authInit(activity: Activity)
+    fun authInit()
 
-    fun logout()
+    suspend fun logout()
 
     suspend fun firebaseAuthWithGoogle(idToken: String): FirebaseUser?
 
@@ -20,5 +21,5 @@ interface LoginRepo {
     fun userMeetingGetQuery(UID : String)
 
     fun userTableCheck(user: FirebaseUser)
-    fun getSignInIntent(): Intent
+    suspend fun requestGoogleLogin(context: Context, successAction: (FirebaseUser?) -> Unit)
 }

--- a/app/src/main/java/com/ping/app/data/repository/login/LoginRepo.kt
+++ b/app/src/main/java/com/ping/app/data/repository/login/LoginRepo.kt
@@ -21,5 +21,5 @@ interface LoginRepo {
     fun userMeetingGetQuery(UID : String)
 
     fun userTableCheck(user: FirebaseUser)
-    suspend fun requestGoogleLogin(context: Context, successAction: (FirebaseUser?) -> Unit)
+    suspend fun requestGoogleLogin(context: Context, onSuccessListener: (FirebaseUser?) -> Unit)
 }

--- a/app/src/main/java/com/ping/app/data/repository/login/LoginRepoImpl.kt
+++ b/app/src/main/java/com/ping/app/data/repository/login/LoginRepoImpl.kt
@@ -4,19 +4,16 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.tasks.Task
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
-import com.google.firebase.auth.GoogleAuthCredential
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.DocumentSnapshot
@@ -36,53 +33,40 @@ private const val TAG = "LoginImpl_싸피"
 class LoginRepoImpl(context: Context) : LoginRepo {
     private val db = Firebase.firestore
     private lateinit var auth: FirebaseAuth
-    private lateinit var googleSignInClient: GoogleSignInClient
     private val credentialManager = CredentialManager.create(context)
-    
+    private val googleIdOption = GetGoogleIdOption.Builder()
+        .setFilterByAuthorizedAccounts(false)
+        .setAutoSelectEnabled(true)
+        .setServerClientId(context.getString(R.string.default_web_client_id))
+        .build()
+
+    private val credentialRequest: GetCredentialRequest = GetCredentialRequest.Builder()
+        .addCredentialOption(googleIdOption)
+        .build()
+
     override fun getCurrentAuth(): FirebaseAuth? {
         return if (::auth.isInitialized) auth else null
     }
-    
-    override fun getSignInIntent(): Intent {
-        return googleSignInClient.signInIntent
-    }
-    
-    override fun logout() {
+
+    override suspend fun logout() {
+        credentialManager.clearCredentialState(request = ClearCredentialStateRequest())
         auth.signOut()
-//        clearCredentialState()
-//        googleSignInClient.signOut()
     }
-    
+
     /**
      * 해당 함수는 파이어베이스의 Authentication을 불러오는 기능을 하는 함수입니다.
      */
-    override fun authInit(activity: Activity) {
-//        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-//            .requestIdToken(activity.getString(R.string.default_web_client_id))
-//            .requestEmail()
-//            .build()
-//
-//        googleSignInClient = GoogleSignIn.getClient(activity, gso)
+    override fun authInit() {
         auth = Firebase.auth
     }
-    
-    suspend fun requestGoogleLogin(
+
+    override suspend fun requestGoogleLogin(
         context: Context,
-        successAction: (FirebaseUser?) -> Unit
+        onSuccessListener: (FirebaseUser?) -> Unit,
     ) {
-        val googleIdOption = GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setAutoSelectEnabled(true)
-            .setServerClientId(context.getString(R.string.default_web_client_id))
-            .build()
-        
-        val request: GetCredentialRequest = GetCredentialRequest.Builder()
-            .addCredentialOption(googleIdOption)
-            .build()
-        
         runCatching {
             credentialManager.getCredential(
-                request = request,
+                request = credentialRequest,
                 context = context,
             )
         }.onSuccess {
@@ -92,7 +76,7 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                         runCatching {
                             GoogleIdTokenCredential.createFrom(credential.data)
                         }.onSuccess { googleIdTokenCredential ->
-                            successAction(
+                            onSuccessListener(
                                 firebaseAuthWithGoogle(googleIdTokenCredential.idToken)
                             )
                         }.onFailure {
@@ -105,7 +89,7 @@ class LoginRepoImpl(context: Context) : LoginRepo {
             Log.d(TAG, "requestGoogleLogin: ${it.localizedMessage ?: "unknown error"}")
         }
     }
-    
+
     /**
      * 해당 부분은 idToken이 유효할 때 파이어 베이스의 Authentication에 접근하여 해당 유저 데이터를 받아옵니다.
      */
@@ -113,29 +97,28 @@ class LoginRepoImpl(context: Context) : LoginRepo {
         var user: FirebaseUser? = null
         val credential = GoogleAuthProvider.getCredential(idToken, null)
         val getUser = CompletableDeferred<FirebaseUser?>()
-        
+
         CoroutineScope(Dispatchers.IO).launch {
             auth.signInWithCredential(credential)
                 .addOnCompleteListener() { task ->
                     if (task.isSuccessful) {
                         Log.d(TAG, "signInWithCredential:success")
                         user = auth.currentUser
-                        
-                        Log.d(TAG, "firebaseAuthWithGoogle2: ${user}")
+                        Log.d(TAG, "firebaseAuthWithGoogle: ${user}")
                         getUser.complete(user)
                     } else {
                         Log.w(TAG, "signInWithCredential:failure", task.exception)
                     }
                 }
         }
-        
+
         getUser.await()
         auth = Firebase.auth
-        
+
         Log.d(TAG, "firebaseAuthWithGoogle1: ${user?.uid}")
         return user
     }
-    
+
     /**
      * 해당 함수에서는 유저 테이블을 학인하고 테이블이 존재한다면 메인으로 넘어가는 함수입니다.
      * 다만 해당 유저의 테이블이 존재하지 않는 다면 해당 유저의 테이블을 만들어 주는 역할을 하는 함수입니다.
@@ -145,12 +128,12 @@ class LoginRepoImpl(context: Context) : LoginRepo {
 //        CoroutineScope(Dispatchers.IO).launch {
 //            createUserTable("1")
 //        }
-        
+
         CoroutineScope(Dispatchers.IO).launch {
             if (userTableCheckQuery(user.uid) == true) { // 해당 UID를 가지는 유저 테이블이 있을 경우
                 // 테이블이 있다면 메인 프래그먼트로 넘어 감
                 Log.d(TAG, "userTableCheck: user table mounted")
-                
+
                 userMeetingGetQuery(user.uid)
             } else { // 해당 UID를 가지는 유저 테이블이 없는 경우
                 // 없을 경우 해당 테이블을 만들어야 함
@@ -159,11 +142,11 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                         true -> { // 유저 테이블 생성 완료
                             Log.d(TAG, "userTableCheck: 유저 테이블 생성을 완료했습니다.")
                         }
-                        
+
                         false -> { // 유저 테이블 생성 실패
                             Log.d(TAG, "userTableCheck: 유저 테이블 생성을 실패했습니다.")
                         }
-                        
+
                         else -> { // 유저 테이블 생성 실패
                             Log.d(TAG, "userTableCheck: 유저 테이블 생성을 실패했습니다.")
                         }
@@ -172,8 +155,8 @@ class LoginRepoImpl(context: Context) : LoginRepo {
             }
         }
     }
-    
-    
+
+
     /**테스트를 완료하지 않았습니다.
      *
      * 아래의 함수는 Firestore에 접근하여 값을 리턴 받는 함수 입니다.
@@ -188,12 +171,12 @@ class LoginRepoImpl(context: Context) : LoginRepo {
     override suspend fun userTableCheckQuery(UID: String): Boolean {
         val getUserTable = CompletableDeferred<Task<DocumentSnapshot>>()
         val uidDocRef = db.collection("USER").document(UID)
-        
+
         CoroutineScope(Dispatchers.IO).launch {
             val result = uidDocRef.get()
             getUserTable.complete(result)
         }
-        
+
         val userTable = getUserTable.await()
         Log.d(TAG, "DocumentSnapshot data:${
             userTable.addOnSuccessListener {
@@ -201,11 +184,11 @@ class LoginRepoImpl(context: Context) : LoginRepo {
             }
         } "
         )
-        
+
         return true
     }
-    
-    
+
+
     /**테스트를 완료하지 않았습니다.
      *
      * 아래의 함수는 만일 유저 테이블이 없을 경우 유저 테이블을 생성하는 함수 입니다.
@@ -213,15 +196,15 @@ class LoginRepoImpl(context: Context) : LoginRepo {
      */
     override suspend fun createUserTable(user: FirebaseUser): Boolean {
         var result = false
-        
-        
+
+
         var inputUser: User = User(
             user.displayName!!,
             user.email!!,
             "",
             UUID.randomUUID().mostSignificantBits.toString()
         )
-        
+
         CoroutineScope(Dispatchers.IO).launch {
             withContext(Dispatchers.IO) {
                 db.collection("USER").document(user.uid)
@@ -231,12 +214,12 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                 result = true
             }
         }.join()
-        
+
         Log.d(TAG, "createUserTable: ${result}")
         return result
     }
-    
-    
+
+
     /**
      * 본 함수는 USER UID로 Meeting Table의 정보를 가져 올 수 있는지 확인 하는 함수입니다.
      */
@@ -254,10 +237,10 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                 Log.d(TAG, "get failed with ", exception)
             }
     }
-    
+
     companion object {
         private var INSTANCE: LoginRepoImpl? = null
-        
+
         fun initialize(context: Context): LoginRepoImpl {
             if (INSTANCE == null) {
                 synchronized(LoginRepoImpl::class.java) {
@@ -268,7 +251,7 @@ class LoginRepoImpl(context: Context) : LoginRepo {
             }
             return INSTANCE!!
         }
-        
+
         fun get(): LoginRepoImpl {
             return INSTANCE!!
         }

--- a/app/src/main/java/com/ping/app/data/repository/login/LoginRepoImpl.kt
+++ b/app/src/main/java/com/ping/app/data/repository/login/LoginRepoImpl.kt
@@ -4,12 +4,19 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
 import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.tasks.Task
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GoogleAuthCredential
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.DocumentSnapshot
@@ -30,54 +37,90 @@ class LoginRepoImpl(context: Context) : LoginRepo {
     private val db = Firebase.firestore
     private lateinit var auth: FirebaseAuth
     private lateinit var googleSignInClient: GoogleSignInClient
-
+    private val credentialManager = CredentialManager.create(context)
+    
     override fun getCurrentAuth(): FirebaseAuth? {
         return if (::auth.isInitialized) auth else null
     }
-
+    
     override fun getSignInIntent(): Intent {
         return googleSignInClient.signInIntent
     }
-
+    
     override fun logout() {
         auth.signOut()
-        googleSignInClient.signOut()
+//        clearCredentialState()
+//        googleSignInClient.signOut()
     }
-
+    
     /**
      * 해당 함수는 파이어베이스의 Authentication을 불러오는 기능을 하는 함수입니다.
-     * 만일 "default_web_client_id"이 빨간색으로 뜰 경우
-     * res 파일이 생성이 안된 문제입니다.
-     * 해당 문제를 해결하기 위해서는 project/gradle의 google service의 버전을 조정해주면 됩니다.
-     * 본 프로젝트에서는 "4.3.13"로 설정을 하였습니다.
      */
     override fun authInit(activity: Activity) {
-        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(activity.getString(R.string.default_web_client_id))
-            .requestEmail()
-            .build()
-
-        googleSignInClient = GoogleSignIn.getClient(activity, gso)
+//        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+//            .requestIdToken(activity.getString(R.string.default_web_client_id))
+//            .requestEmail()
+//            .build()
+//
+//        googleSignInClient = GoogleSignIn.getClient(activity, gso)
         auth = Firebase.auth
     }
-
+    
+    suspend fun requestGoogleLogin(
+        context: Context,
+        successAction: (FirebaseUser?) -> Unit
+    ) {
+        val googleIdOption = GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false)
+            .setAutoSelectEnabled(true)
+            .setServerClientId(context.getString(R.string.default_web_client_id))
+            .build()
+        
+        val request: GetCredentialRequest = GetCredentialRequest.Builder()
+            .addCredentialOption(googleIdOption)
+            .build()
+        
+        runCatching {
+            credentialManager.getCredential(
+                request = request,
+                context = context,
+            )
+        }.onSuccess {
+            when (val credential = it.credential) {
+                is CustomCredential -> {
+                    if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                        runCatching {
+                            GoogleIdTokenCredential.createFrom(credential.data)
+                        }.onSuccess { googleIdTokenCredential ->
+                            successAction(
+                                firebaseAuthWithGoogle(googleIdTokenCredential.idToken)
+                            )
+                        }.onFailure {
+                            Log.e(TAG, "Received an invalid google id token response", it)
+                        }
+                    }
+                }
+            }
+        }.onFailure {
+            Log.d(TAG, "requestGoogleLogin: ${it.localizedMessage ?: "unknown error"}")
+        }
+    }
+    
     /**
-     * 해당 부분은 파이어 베이스의 Authentication에 접근하여 해당 유저의 데이터 값을 가져오는 함수로 추정돱니다.
+     * 해당 부분은 idToken이 유효할 때 파이어 베이스의 Authentication에 접근하여 해당 유저 데이터를 받아옵니다.
      */
     override suspend fun firebaseAuthWithGoogle(idToken: String): FirebaseUser? {
         var user: FirebaseUser? = null
         val credential = GoogleAuthProvider.getCredential(idToken, null)
-
         val getUser = CompletableDeferred<FirebaseUser?>()
-
+        
         CoroutineScope(Dispatchers.IO).launch {
             auth.signInWithCredential(credential)
                 .addOnCompleteListener() { task ->
                     if (task.isSuccessful) {
-                        // Sign in success, update UI with the signed-in user's information
                         Log.d(TAG, "signInWithCredential:success")
                         user = auth.currentUser
-
+                        
                         Log.d(TAG, "firebaseAuthWithGoogle2: ${user}")
                         getUser.complete(user)
                     } else {
@@ -85,13 +128,14 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                     }
                 }
         }
-
+        
         getUser.await()
-
+        auth = Firebase.auth
+        
         Log.d(TAG, "firebaseAuthWithGoogle1: ${user?.uid}")
         return user
     }
-
+    
     /**
      * 해당 함수에서는 유저 테이블을 학인하고 테이블이 존재한다면 메인으로 넘어가는 함수입니다.
      * 다만 해당 유저의 테이블이 존재하지 않는 다면 해당 유저의 테이블을 만들어 주는 역할을 하는 함수입니다.
@@ -101,15 +145,13 @@ class LoginRepoImpl(context: Context) : LoginRepo {
 //        CoroutineScope(Dispatchers.IO).launch {
 //            createUserTable("1")
 //        }
-
+        
         CoroutineScope(Dispatchers.IO).launch {
             if (userTableCheckQuery(user.uid) == true) { // 해당 UID를 가지는 유저 테이블이 있을 경우
                 // 테이블이 있다면 메인 프래그먼트로 넘어 감
                 Log.d(TAG, "userTableCheck: user table mounted")
-
+                
                 userMeetingGetQuery(user.uid)
-
-
             } else { // 해당 UID를 가지는 유저 테이블이 없는 경우
                 // 없을 경우 해당 테이블을 만들어야 함
                 CoroutineScope(Dispatchers.IO).launch {
@@ -117,11 +159,11 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                         true -> { // 유저 테이블 생성 완료
                             Log.d(TAG, "userTableCheck: 유저 테이블 생성을 완료했습니다.")
                         }
-
+                        
                         false -> { // 유저 테이블 생성 실패
                             Log.d(TAG, "userTableCheck: 유저 테이블 생성을 실패했습니다.")
                         }
-
+                        
                         else -> { // 유저 테이블 생성 실패
                             Log.d(TAG, "userTableCheck: 유저 테이블 생성을 실패했습니다.")
                         }
@@ -130,8 +172,8 @@ class LoginRepoImpl(context: Context) : LoginRepo {
             }
         }
     }
-
-
+    
+    
     /**테스트를 완료하지 않았습니다.
      *
      * 아래의 함수는 Firestore에 접근하여 값을 리턴 받는 함수 입니다.
@@ -146,12 +188,12 @@ class LoginRepoImpl(context: Context) : LoginRepo {
     override suspend fun userTableCheckQuery(UID: String): Boolean {
         val getUserTable = CompletableDeferred<Task<DocumentSnapshot>>()
         val uidDocRef = db.collection("USER").document(UID)
-
+        
         CoroutineScope(Dispatchers.IO).launch {
             val result = uidDocRef.get()
             getUserTable.complete(result)
         }
-
+        
         val userTable = getUserTable.await()
         Log.d(TAG, "DocumentSnapshot data:${
             userTable.addOnSuccessListener {
@@ -159,11 +201,11 @@ class LoginRepoImpl(context: Context) : LoginRepo {
             }
         } "
         )
-
+        
         return true
     }
-
-
+    
+    
     /**테스트를 완료하지 않았습니다.
      *
      * 아래의 함수는 만일 유저 테이블이 없을 경우 유저 테이블을 생성하는 함수 입니다.
@@ -171,15 +213,15 @@ class LoginRepoImpl(context: Context) : LoginRepo {
      */
     override suspend fun createUserTable(user: FirebaseUser): Boolean {
         var result = false
-
-
+        
+        
         var inputUser: User = User(
             user.displayName!!,
             user.email!!,
             "",
             UUID.randomUUID().mostSignificantBits.toString()
         )
-
+        
         CoroutineScope(Dispatchers.IO).launch {
             withContext(Dispatchers.IO) {
                 db.collection("USER").document(user.uid)
@@ -189,12 +231,12 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                 result = true
             }
         }.join()
-
+        
         Log.d(TAG, "createUserTable: ${result}")
         return result
     }
-
-
+    
+    
     /**
      * 본 함수는 USER UID로 Meeting Table의 정보를 가져 올 수 있는지 확인 하는 함수입니다.
      */
@@ -212,10 +254,10 @@ class LoginRepoImpl(context: Context) : LoginRepo {
                 Log.d(TAG, "get failed with ", exception)
             }
     }
-
+    
     companion object {
         private var INSTANCE: LoginRepoImpl? = null
-
+        
         fun initialize(context: Context): LoginRepoImpl {
             if (INSTANCE == null) {
                 synchronized(LoginRepoImpl::class.java) {
@@ -226,7 +268,7 @@ class LoginRepoImpl(context: Context) : LoginRepo {
             }
             return INSTANCE!!
         }
-
+        
         fun get(): LoginRepoImpl {
             return INSTANCE!!
         }

--- a/app/src/main/java/com/ping/app/ui/ui/container/MainActivity.kt
+++ b/app/src/main/java/com/ping/app/ui/ui/container/MainActivity.kt
@@ -16,6 +16,8 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.gun0912.tedpermission.PermissionListener
 import com.gun0912.tedpermission.normal.TedPermission
 import com.ping.app.R
+import com.ping.app.data.repository.login.LoginRepo
+import com.ping.app.data.repository.login.LoginRepoImpl
 import com.ping.app.databinding.ActivityMainBinding
 import com.ping.app.ui.presentation.map.PingMapViewModel
 import com.ping.app.ui.ui.util.FCM
@@ -34,6 +36,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        LoginRepoImpl.get().authInit()
         createNotificationChannel(FCM.CHANNEL_ID, FCM.CHANNEL_NAME)
         initView()
     }

--- a/app/src/main/java/com/ping/app/ui/ui/feature/login/LoginFragment.kt
+++ b/app/src/main/java/com/ping/app/ui/ui/feature/login/LoginFragment.kt
@@ -2,22 +2,16 @@ package com.ping.app.ui.ui.feature.login
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.common.api.ApiException
 import com.google.firebase.auth.FirebaseUser
 import com.ping.app.R
 import com.ping.app.data.repository.login.LoginRepoImpl
 import com.ping.app.databinding.FragmentLoginBinding
+import com.ping.app.ui.base.BaseFragment
 import com.ping.app.ui.presentation.MainActivityViewModel
 import com.ping.app.ui.presentation.login.LoginViewModel
-import com.ping.app.ui.base.BaseFragment
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 
@@ -29,16 +23,9 @@ private const val TAG = "LoginFragment_싸피"
 class LoginFragment : BaseFragment<FragmentLoginBinding, LoginViewModel>(R.layout.fragment_login) {
     override val viewModel: LoginViewModel by viewModels()
     private val mainActivityViewModel: MainActivityViewModel by viewModels()
-    private lateinit var googleSignInLauncher: ActivityResultLauncher<Intent>
     private val loginRepoInstance = LoginRepoImpl.get()
-    
+
     override fun initView(savedInstanceState: Bundle?) {
-        loginRepoInstance.authInit(requireActivity())
-        lifecycleScope.launch {
-            loginRepoInstance.requestGoogleLogin(binding.root.context) { firebaseUser ->
-                updateUI(firebaseUser)
-            }
-        }
         binding.apply {
             loginButton.setOnClickListener {
                 lifecycleScope.launch {
@@ -48,8 +35,9 @@ class LoginFragment : BaseFragment<FragmentLoginBinding, LoginViewModel>(R.layou
                 }
             }
             logoutButton.setOnClickListener {
-                loginRepoInstance.logout()
-                updateUI(null)
+                lifecycleScope.launch {
+                    loginRepoInstance.logout()
+                }
             }
         }
     }

--- a/app/src/main/java/com/ping/app/ui/ui/feature/login/LoginFragment.kt
+++ b/app/src/main/java/com/ping/app/ui/ui/feature/login/LoginFragment.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.common.api.ApiException
 import com.google.firebase.auth.FirebaseUser
@@ -30,27 +31,21 @@ class LoginFragment : BaseFragment<FragmentLoginBinding, LoginViewModel>(R.layou
     private val mainActivityViewModel: MainActivityViewModel by viewModels()
     private lateinit var googleSignInLauncher: ActivityResultLauncher<Intent>
     private val loginRepoInstance = LoginRepoImpl.get()
-
-    /**
-     * 로그인 프래그먼트의 시작 부분입니다.
-     * 해당 함수의 역할은 아래와 같습니다.
-     * 1. 사용자 인증을 초기화
-     * 2, 로그인 버튼 클릭시 signIn() 함수가 호출됩니다.
-     */
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        googleSignInLauncher =
-            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-                googleSignIn(result.data)
-            }
-    }
-
+    
     override fun initView(savedInstanceState: Bundle?) {
         loginRepoInstance.authInit(requireActivity())
+        lifecycleScope.launch {
+            loginRepoInstance.requestGoogleLogin(binding.root.context) { firebaseUser ->
+                updateUI(firebaseUser)
+            }
+        }
         binding.apply {
             loginButton.setOnClickListener {
-                googleSignInLauncher.launch(loginRepoInstance.getSignInIntent())
+                lifecycleScope.launch {
+                    loginRepoInstance.requestGoogleLogin(binding.root.context) { firebaseUser ->
+                        updateUI(firebaseUser)
+                    }
+                }
             }
             logoutButton.setOnClickListener {
                 loginRepoInstance.logout()
@@ -58,7 +53,7 @@ class LoginFragment : BaseFragment<FragmentLoginBinding, LoginViewModel>(R.layou
             }
         }
     }
-
+    
     /**
      * onStart시에 user상태를 확인해서 자동로그인을 해주는 로직
      */
@@ -67,25 +62,6 @@ class LoginFragment : BaseFragment<FragmentLoginBinding, LoginViewModel>(R.layou
         loginRepoInstance.getCurrentAuth()?.let { auth ->
             updateUI(auth.currentUser)
             getUserUid(auth.currentUser)
-        }
-    }
-
-    /**
-     * onActivityResult대신에 registerForActivityResult를 사용한 구글 로그인 구현
-     * deprecated된 부분은 추후 수정
-     */
-    private fun googleSignIn(data: Intent?) {
-        runCatching {
-            val task = GoogleSignIn.getSignedInAccountFromIntent(data)
-            task.getResult(ApiException::class.java)
-        }.onSuccess { account ->
-            Log.d(TAG, "firebaseAuthWithGoogle:" + account.id + "||" + account.idToken)
-            CoroutineScope(Dispatchers.Main).launch {
-                val user = loginRepoInstance.firebaseAuthWithGoogle(account.idToken!!)
-                updateUI(user)
-            }
-        }.onFailure {
-            Log.w(TAG, "Google sign in failed@@@@@@@@@", it)
         }
     }
 
@@ -101,7 +77,7 @@ class LoginFragment : BaseFragment<FragmentLoginBinding, LoginViewModel>(R.layou
             "인증 실패"
         }
     }
-
+    
     /**
      * 해당 함수는 유저의 Uid를 MainActivity의 Viewmodel에 저장하는 기능을 가진 함수입니다.
      * mainViewmodel에 넣은 이유는 user의 uid가 메인 액티비티가 살아있는 동안은 계속

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,6 +25,10 @@ object Google {
     const val FIREBASE_CLOUD_MESSAGING = "com.google.firebase:firebase-messaging-ktx"
     const val FIREBASE_CLOUD_FUNCTION =
         "com.google.firebase:firebase-functions-ktx:${Versions.FIREBASE_CLOUD_FUNCTION}"
+    const val CREDENTIAL = "androidx.credentials:credentials:${Versions.CREDENTIAL}"
+    const val CREDENTIAL_PLAY_SERVICE =
+        "androidx.credentials:credentials-play-services-auth:${Versions.CREDENTIAL}"
+    const val GOOGLE_ID="com.google.android.libraries.identity.googleid:googleid:${Versions.GOOGLE_ID}"
 }
 
 object Permission {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -13,4 +13,7 @@ object Versions {
     const val APPCOMPAT = "1.6.1"
     const val CORE_KTX = "1.12.0"
     const val NAVIGATION = "2.7.7"
+    const val CREDENTIAL = "1.3.0-alpha03"
+    const val GOOGLE_ID = "1.1.0"
+    
 }


### PR DESCRIPTION
- Deprecated된 GoogleSignIn을 다 걷어내고 CredentialManager로 전환
- 처음에  LoginRepoImpl에서 
```kotlin
private val googleIdOption = GetGoogleIdOption.Builder()
        .setFilterByAuthorizedAccounts(false)
        .setAutoSelectEnabled(true)
        .setServerClientId(context.getString(R.string.default_web_client_id))
        .build()

    private val credentialRequest: GetCredentialRequest = GetCredentialRequest.Builder()
        .addCredentialOption(googleIdOption)
        .build()
```
이 두 코드를 인스턴스 생성할 때 초기화해주는데, 약간의 지연이 있으므로 추후 splash에 넣으면 될 것 같다.