### PR TITLE
Feature/#21 retrofit setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         manifestPlaceholders["NAVER_MAP_CLIENT_ID"] = getAppKey("NAVER_MAP_CLIENT_ID")
+        buildConfigField("String", "CHAT_GPT", getAppKey("CHAT_GPT"))
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     
@@ -44,6 +45,7 @@ android {
     }
     buildFeatures {
         dataBinding = true
+        buildConfig = true
     }
 }
 
@@ -73,4 +75,8 @@ dependencies {
     implementation(Permission.TED_NORMAL)
     implementation(Permission.TED_COROUTINE)
     implementation(Square.GLIDE)
+    implementation(Square.RETROFIT2)
+    implementation(Square.OKHTTP3)
+    implementation(Square.OKHTTP3_LOGGING)
+    implementation(Square.RETROFIT2_CONVERTER_GSON)
 }

--- a/app/src/main/java/com/ping/app/PingApplication.kt
+++ b/app/src/main/java/com/ping/app/PingApplication.kt
@@ -2,9 +2,10 @@ package com.ping.app
 
 import android.app.Application
 import android.content.Context
-import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.ping.app.data.repository.chatgpt.ChatGPTRepo
+import com.ping.app.data.repository.chatgpt.ChatGPTRepoImpl
 import com.ping.app.data.repository.login.LoginRepo
 import com.ping.app.data.repository.login.LoginRepoImpl
 import com.ping.app.data.repository.main.MainRepo
@@ -22,11 +23,12 @@ class PingApplication : Application() {
         pingMapRepo = PingMapRepoImpl.initialize(this)
         loginRepo = LoginRepoImpl.initialize(this)
         mainRepo = MainRepoImpl.initialize(this)
+        gptRepo = ChatGPTRepoImpl.initialize()
     }
     
     companion object {
         val UID_TOKEN = stringPreferencesKey("uid")
-        
+        lateinit var gptRepo: ChatGPTRepo
         lateinit var locationHelper: LocationHelper
         lateinit var pingMapRepo: PingMapRepo
         lateinit var loginRepo: LoginRepo

--- a/app/src/main/java/com/ping/app/data/model/gpt/ChatGptRequest.kt
+++ b/app/src/main/java/com/ping/app/data/model/gpt/ChatGptRequest.kt
@@ -1,0 +1,9 @@
+package com.ping.app.data.model.gpt
+
+import com.google.gson.annotations.SerializedName
+
+data class ChatGptRequest(
+    @SerializedName("model") val model: String,
+    @SerializedName("messages") val messages: List<Message>
+)
+

--- a/app/src/main/java/com/ping/app/data/model/gpt/ChatGptResponse.kt
+++ b/app/src/main/java/com/ping/app/data/model/gpt/ChatGptResponse.kt
@@ -1,0 +1,7 @@
+package com.ping.app.data.model.gpt
+
+import com.google.gson.annotations.SerializedName
+
+data class ChatGptResponse(
+    @SerializedName("choices") val choices: List<Choice>
+)

--- a/app/src/main/java/com/ping/app/data/model/gpt/Choice.kt
+++ b/app/src/main/java/com/ping/app/data/model/gpt/Choice.kt
@@ -1,0 +1,7 @@
+package com.ping.app.data.model.gpt
+
+import com.google.gson.annotations.SerializedName
+
+data class Choice(
+    @SerializedName("message") val message: Message
+)

--- a/app/src/main/java/com/ping/app/data/model/gpt/Message.kt
+++ b/app/src/main/java/com/ping/app/data/model/gpt/Message.kt
@@ -1,0 +1,8 @@
+package com.ping.app.data.model.gpt
+
+import com.google.gson.annotations.SerializedName
+
+data class Message(
+    @SerializedName("role") val role: String,
+    @SerializedName("content") val content: String
+)

--- a/app/src/main/java/com/ping/app/data/remote/ChatGPTService.kt
+++ b/app/src/main/java/com/ping/app/data/remote/ChatGPTService.kt
@@ -1,0 +1,14 @@
+package com.ping.app.data.remote
+
+import com.ping.app.data.model.gpt.ChatGptRequest
+import com.ping.app.data.model.gpt.ChatGptResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.POST
+
+interface ChatGPTService {
+    @Headers("Content-Type: application/json")
+    @POST("v1/chat/completions")
+    suspend fun getChatCompletion(@Body request: ChatGptRequest): Response<ChatGptResponse>
+}

--- a/app/src/main/java/com/ping/app/data/remote/NetworkModule.kt
+++ b/app/src/main/java/com/ping/app/data/remote/NetworkModule.kt
@@ -1,0 +1,35 @@
+package com.ping.app.data.remote
+
+import com.ping.app.BuildConfig
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object NetworkModule {
+    private const val BASE_URL = "https://api.openai.com/"
+    
+    private val loggingInterceptor = HttpLoggingInterceptor().apply {
+        setLevel(HttpLoggingInterceptor.Level.BODY)
+    }
+    
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .addInterceptor { chain ->
+            val bearer = "Bearer ${BuildConfig.CHAT_GPT}"
+            val request = chain.request().newBuilder()
+                .addHeader("Authorization", bearer)
+                .build()
+            chain.proceed(request)
+        }
+        .build()
+    
+    val api: ChatGPTService by lazy {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ChatGPTService::class.java)
+    }
+}

--- a/app/src/main/java/com/ping/app/data/repository/TestRepo.kt
+++ b/app/src/main/java/com/ping/app/data/repository/TestRepo.kt
@@ -1,4 +1,0 @@
-package com.ping.app.data.repository
-
-interface TestRepo {
-}

--- a/app/src/main/java/com/ping/app/data/repository/TestRepoImpl.kt
+++ b/app/src/main/java/com/ping/app/data/repository/TestRepoImpl.kt
@@ -1,5 +1,0 @@
-package com.ping.app.data.repository
-
-class TestRepoImpl {
-
-}

--- a/app/src/main/java/com/ping/app/data/repository/chatgpt/ChatGPTRepo.kt
+++ b/app/src/main/java/com/ping/app/data/repository/chatgpt/ChatGPTRepo.kt
@@ -1,0 +1,8 @@
+package com.ping.app.data.repository.chatgpt
+
+import com.ping.app.data.model.gpt.ChatGptResponse
+import com.ping.app.data.model.gpt.Message
+
+interface ChatGPTRepo {
+    suspend fun getChatCompletion(messages: List<Message>): ChatGptResponse
+}

--- a/app/src/main/java/com/ping/app/data/repository/chatgpt/ChatGPTRepoImpl.kt
+++ b/app/src/main/java/com/ping/app/data/repository/chatgpt/ChatGPTRepoImpl.kt
@@ -1,11 +1,13 @@
 package com.ping.app.data.repository.chatgpt
 
+import android.util.Log
 import com.ping.app.data.model.gpt.ChatGptRequest
 import com.ping.app.data.model.gpt.ChatGptResponse
 import com.ping.app.data.model.gpt.Message
 import com.ping.app.data.remote.NetworkModule
 import kotlinx.coroutines.CompletableDeferred
 
+private const val TAG = "ChatGPTRepoImpl_싸피"
 class ChatGPTRepoImpl: ChatGPTRepo {
     private val api = NetworkModule.api
     
@@ -19,8 +21,9 @@ class ChatGPTRepoImpl: ChatGPTRepo {
             it.body()?.let {
                 gptAnswer.complete(it)
             }
-        }.onFailure {
-            gptAnswer.completeExceptionally(Throwable("ChatGPT 호출 실패"))
+            it.errorBody()?.let {
+                gptAnswer.completeExceptionally(Throwable("잘못된 값으로 요청했습니다."))
+            }
         }
         return gptAnswer.await()
     }

--- a/app/src/main/java/com/ping/app/data/repository/chatgpt/ChatGPTRepoImpl.kt
+++ b/app/src/main/java/com/ping/app/data/repository/chatgpt/ChatGPTRepoImpl.kt
@@ -1,0 +1,45 @@
+package com.ping.app.data.repository.chatgpt
+
+import com.ping.app.data.model.gpt.ChatGptRequest
+import com.ping.app.data.model.gpt.ChatGptResponse
+import com.ping.app.data.model.gpt.Message
+import com.ping.app.data.remote.NetworkModule
+import kotlinx.coroutines.CompletableDeferred
+
+class ChatGPTRepoImpl: ChatGPTRepo {
+    private val api = NetworkModule.api
+    
+    override suspend fun getChatCompletion(messages: List<Message>): ChatGptResponse {
+        val request = ChatGptRequest(
+            model = "gpt-3.5-turbo",
+            messages = messages
+        )
+        val gptAnswer = CompletableDeferred<ChatGptResponse>()
+        runCatching { api.getChatCompletion(request) }.onSuccess {
+            it.body()?.let {
+                gptAnswer.complete(it)
+            }
+        }.onFailure {
+            gptAnswer.completeExceptionally(Throwable("ChatGPT 호출 실패"))
+        }
+        return gptAnswer.await()
+    }
+    
+    companion object {
+        private var instance: ChatGPTRepoImpl? = null
+        fun initialize(): ChatGPTRepoImpl {
+            if (instance == null) {
+                synchronized(ChatGPTRepoImpl::class.java) {
+                    if (instance == null) {
+                        instance = ChatGPTRepoImpl()
+                    }
+                }
+            }
+            return instance!!
+        }
+        
+        fun getInstance(): ChatGPTRepoImpl {
+            return instance!!
+        }
+    }
+}

--- a/app/src/main/java/com/ping/app/data/repository/cloudfunction/CloudFunctionRepo.kt
+++ b/app/src/main/java/com/ping/app/data/repository/cloudfunction/CloudFunctionRepo.kt
@@ -1,4 +1,0 @@
-package com.ping.app.data.repository.cloudfunction
-
-interface CloudFunctionRepo {
-}

--- a/app/src/main/java/com/ping/app/data/repository/cloudfunction/CloudFunctionRepoImpl.kt
+++ b/app/src/main/java/com/ping/app/data/repository/cloudfunction/CloudFunctionRepoImpl.kt
@@ -1,9 +1,0 @@
-package com.ping.app.data.repository.cloudfunction
-
-import com.google.firebase.functions.FirebaseFunctions
-import com.google.firebase.functions.ktx.functions
-import com.google.firebase.ktx.Firebase
-
-class CloudFunctionRepoImpl: CloudFunctionRepo {
-    private var functions: FirebaseFunctions = Firebase.functions
-}

--- a/app/src/main/java/com/ping/app/ui/ui/feature/main/MainFragment.kt
+++ b/app/src/main/java/com/ping/app/ui/ui/feature/main/MainFragment.kt
@@ -46,10 +46,15 @@ class MainFragment : BaseFragment<FragmentMainBinding, MainViewModel>(R.layout.f
         lifecycleScope.launch {
             // TODO: GPT 쓰는 예제
             val messages = listOf(
-                Message(role = "user", content = "오늘 뭐하면 좋을까?")
+                Message(role = "use4r", content = "오늘 뭐하면 좋을까?")
             )
-            val res = ChatGPTRepoImpl.getInstance().getChatCompletion(messages)
-            Log.d(TAG, "initView: ${res.choices}\n ")
+            runCatching {
+                ChatGPTRepoImpl.getInstance().getChatCompletion(messages)
+            }.onSuccess {
+                Log.d(TAG, "initView: ${it.choices}\n ")
+            }.onFailure {
+                Log.d(TAG, "initView: ${it}\n ")
+            }
         }
         
         lifecycleScope.launch {

--- a/app/src/main/java/com/ping/app/ui/ui/feature/main/MainFragment.kt
+++ b/app/src/main/java/com/ping/app/ui/ui/feature/main/MainFragment.kt
@@ -46,7 +46,7 @@ class MainFragment : BaseFragment<FragmentMainBinding, MainViewModel>(R.layout.f
         lifecycleScope.launch {
             // TODO: GPT 쓰는 예제
             val messages = listOf(
-                Message(role = "use4r", content = "오늘 뭐하면 좋을까?")
+                Message(role = "user", content = "오늘 뭐하면 좋을까?")
             )
             runCatching {
                 ChatGPTRepoImpl.getInstance().getChatCompletion(messages)

--- a/app/src/main/java/com/ping/app/ui/ui/feature/main/MainFragment.kt
+++ b/app/src/main/java/com/ping/app/ui/ui/feature/main/MainFragment.kt
@@ -1,6 +1,7 @@
 package com.ping.app.ui.ui.feature.main
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -11,6 +12,8 @@ import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.ping.app.R
 import com.ping.app.data.model.Gathering
+import com.ping.app.data.model.gpt.Message
+import com.ping.app.data.repository.chatgpt.ChatGPTRepoImpl
 import com.ping.app.data.repository.login.LoginRepoImpl
 import com.ping.app.data.repository.main.MainRepoImpl
 import com.ping.app.databinding.FragmentMainBinding
@@ -39,6 +42,16 @@ class MainFragment : BaseFragment<FragmentMainBinding, MainViewModel>(R.layout.f
     
     override fun initView(savedInstanceState: Bundle?) {
         val user = LoginRepoImpl.get().getUserInfo()!!
+        
+        lifecycleScope.launch {
+            // TODO: GPT 쓰는 예제
+            val messages = listOf(
+                Message(role = "user", content = "오늘 뭐하면 좋을까?")
+            )
+            val res = ChatGPTRepoImpl.getInstance().getChatCompletion(messages)
+            Log.d(TAG, "initView: ${res.choices}\n ")
+        }
+        
         lifecycleScope.launch {
             val duplicateResult =
                 MainRepoImpl.get().meetingDuplicateCheck(LoginRepoImpl.get().getAccessToken())

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -46,11 +46,10 @@ object UnitTest {
 }
 
 object Square {
-    //    const val RETROFIT2 = "com.squareup.retrofit2:retrofit:${Versions.RETROFIT2}"
-//    const val RETROFIT2_CONVERTER_GSON =
-//        "com.squareup.retrofit2:converter-gson:${Versions.RETROFIT2}"
-//    const val OKHTTP3_BOM = "com.squareup.okhttp3:okhttp-bom:${Versions.OKHTTP3_BOM}"
-    const val OKHTTP3 = "com.squareup.okhttp3:okhttp"
-    const val OKHTTP3_LOGGING = "com.squareup.okhttp3:logging-interceptor"
+    const val RETROFIT2 = "com.squareup.retrofit2:retrofit:${Versions.RETROFIT2}"
+    const val RETROFIT2_CONVERTER_GSON =
+        "com.squareup.retrofit2:converter-gson:${Versions.RETROFIT2}"
+    const val OKHTTP3 = "com.squareup.okhttp3:okhttp:${Versions.OKHTTP3}"
+    const val OKHTTP3_LOGGING = "com.squareup.okhttp3:logging-interceptor:${Versions.OKHTTP3}"
     const val GLIDE = "com.github.bumptech.glide:glide:${Versions.GLIDE}"
 }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,4 +1,6 @@
 object Versions {
+    const val OKHTTP3 = "4.9.1"
+    const val RETROFIT2 = "2.11.0"
     const val DATASTORE = "1.1.1"
     const val TED = "3.3.0"
     const val FIREBASE_CLOUD_FUNCTION = "20.4.0"


### PR DESCRIPTION
# ChatGPT 연동

```kotlin
data class ChatGptResponse(
    @SerializedName("choices") val choices: List<Choice>
)

data class Choice(
    @SerializedName("message") val message: Message
)

data class Message(
    @SerializedName("role") val role: String,
    @SerializedName("content") val content: String
)
```

choice로 response가 내려옵니다

```kotlin
        lifecycleScope.launch {
            // TODO: GPT 쓰는 예제
            val messages = listOf(
                Message(role = "user", content = "오늘 뭐하면 좋을까?")
            )
            val res = ChatGPTRepoImpl.getInstance().getChatCompletion(messages)
            Log.d(TAG, "initView: ${res.choices}\n ")
        }
```

role에 user는 고정이고, content로 입력값을 넣으면 됩니다.